### PR TITLE
Alteração do menu lateral para refletir o comportamento já existente no tainacan

### DIFF
--- a/classes/Admin/AdminMenu.php
+++ b/classes/Admin/AdminMenu.php
@@ -4,63 +4,68 @@ namespace Obatala\Admin;
 
 class AdminMenu {
     /**
-     * Adiciona as páginas de administração ao menu do WordPress.
+     * Inicializa o hook para adicionar as páginas de administração ao menu do WordPress.
      */
-    public static function add_admin_pages() {
-        // Array contendo os detalhes das páginas de administração.
-        $pages = [
-            'process-manager' => [
-                'title' => __('Process Manager', 'obatala'),
-                'menu_title' => __('Process Manager', 'obatala'),
-                'capability' => 'manage_options', // Capacidade necessária para acessar esta página.
-                'icon' => 'dashicons-media-document',
-                'position' => -1,
-            ],
-            'process-type-manager' => [
-                'title' => __('Process Type Manager', 'obatala'),
-                'menu_title' => __('Process Type Manager', 'obatala'),
-                'capability' => 'edit_posts', // Capacidade necessária para acessar esta página.
-                'icon' => 'dashicons-admin-generic',
-                'position' => -1,
-            ],
-            'process-viewer' => [
-                'title' => __('Process Viewer', 'obatala'),
-                'menu_title' => __('Process Viewer', 'obatala'),
-                'capability' => 'read', // Capacidade necessária para acessar esta página.
-                'icon' => 'dashicons-visibility',
-                'position' => -1,
-            ], 
-            'process-step-manager' => [
-                'title' => __('Step Manager', 'obatala'),
-                'menu_title' => __('Step Manager', 'obatala'),
-                'capability' => 'manage_options', // Capacidade necessária para acessar esta página.
-                'icon' => 'dashicons-admin-tools',
-                'position' => -1,
-            ],
-        ];
-
-        // Chama a função que cria as páginas de administração.
-        self::create_admin_pages($pages);
+    public static function init() {
+        add_action('admin_menu', [self::class, 'add_admin_pages']);
+        add_action('admin_enqueue_scripts', [self::class, 'enqueue_scripts']);
     }
 
     /**
-     * Cria as páginas de administração com base nos detalhes fornecidos.
-     *
-     * @param array $pages Array contendo os detalhes das páginas de administração.
+     * Adiciona as páginas de administração ao menu do WordPress.
      */
-    private static function create_admin_pages($pages) {
-        // Itera sobre o array de páginas e adiciona cada uma ao menu de administração.
-        foreach ($pages as $slug => $page) {
-            add_menu_page(
-                $page['title'], // Título da página.
-                $page['menu_title'], // Título do menu.
-                $page['capability'], // Capacidade necessária para acessar a página.
-                $slug, // Slug da página.
-                [self::class, 'render_page'], // Função de callback para renderizar a página.
-                $page['icon'], // Ícone do menu.
-                $page['position'] // Posição no menu.
-            );
-        }
+    public static function add_admin_pages() {
+        // Adiciona o menu principal "Obatala".
+        add_menu_page(
+            __('Obatala', 'obatala'), // Título da página principal.
+            __('Obatala', 'obatala'), // Título do menu principal.
+            'manage_options', // Capacidade necessária para acessar o menu principal.
+            'obatala-main', // Slug da página principal.
+            function() {
+                // Exibe uma mensagem ou uma página básica para o menu principal.
+                echo '<h1>' . __('Bem-vindo ao Obatala', 'obatala') . '</h1>';
+                echo '<p>' . __('Selecione uma opção do submenu para começar.', 'obatala') . '</p>';
+            }, // Função de callback para exibir o conteúdo do menu principal.
+            'dashicons-admin-site', // Ícone do menu principal.
+            2 // Posição no menu.
+        );
+
+        // Adiciona os submenus.
+        add_submenu_page(
+            'obatala-main',
+            __('Process Manager', 'obatala'),
+            __('Process Manager', 'obatala'),
+            'manage_options',
+            'process-manager',
+            [self::class, 'render_page']
+        );
+
+        add_submenu_page(
+            'obatala-main',
+            __('Process Type Manager', 'obatala'),
+            __('Process Type Manager', 'obatala'),
+            'edit_posts',
+            'process-type-manager',
+            [self::class, 'render_page']
+        );
+
+        add_submenu_page(
+            'obatala-main',
+            __('Process Viewer', 'obatala'),
+            __('Process Viewer', 'obatala'),
+            'read',
+            'process-viewer',
+            [self::class, 'render_page'] 
+        );
+
+        add_submenu_page(
+            'obatala-main',
+            __('Step Manager', 'obatala'),
+            __('Step Manager', 'obatala'),
+            'manage_options',
+            'process-step-manager',
+            [self::class, 'render_page']
+        );
     }
 
     /**
@@ -73,18 +78,38 @@ class AdminMenu {
 
         // Verifica o ID da tela e renderiza a div correspondente.
         switch ($page_id) {
-            case 'toplevel_page_process-manager':
+            case 'obatala_page_process-manager':
                 echo '<div id="process-manager"></div>';
                 break;
-            case 'toplevel_page_process-type-manager':
+            case 'obatala_page_process-type-manager':
                 echo '<div id="process-type-manager"></div>';
                 break;
-            case 'toplevel_page_process-viewer':
+            case 'obatala_page_process-viewer':
                 echo '<div id="process-viewer"></div>';
                 break;
-            case 'toplevel_page_process-step-manager':
+            case 'obatala_page_process-step-manager':
                 echo '<div id="process-step-manager"></div>';
+                break;
+            default:
+                echo '<h1>Page Not Found</h1>';
                 break;
         }
     }
+    /**
+     * Enfileira os scripts necessários para garantir o comportamento do menu.
+     */
+    public static function enqueue_scripts() {
+        // Adiciona o script para manter o menu aberto somente ao passar o mouse sobre "Obatala".
+        add_action('admin_footer', function() {
+            echo '<style>
+                #toplevel_page_obatala-main.wp-menu-open > .wp-submenu {
+                    display: block;
+                }
+                #toplevel_page_obatala-main:hover > .wp-submenu {
+                    display: block;
+                }
+            </style>';
+        });
+    }
 }
+

--- a/classes/Admin/Enqueuer.php
+++ b/classes/Admin/Enqueuer.php
@@ -11,10 +11,10 @@ if (!defined('ABSPATH')) {
 class Enqueuer {
     // Propriedade estática que mapeia as páginas de administração aos seus IDs
     private static $pages = [
-        'toplevel_page_process-manager' => 'process-manager',
-        'toplevel_page_process-type-manager' => 'process-type-manager',
-        'toplevel_page_process-viewer' => 'process-viewer',
-        'toplevel_page_process-step-manager' => 'process-step-manager',
+        'obatala_page_process-manager' => 'process-manager',
+        'obatala_page_process-type-manager' => 'process-type-manager',
+        'obatala_page_process-viewer' => 'process-viewer',
+        'obatala_page_process-step-manager' => 'process-step-manager',
         // Adicione mais páginas conforme necessário
     ];
 


### PR DESCRIPTION
Foi feito a alteração do menu de navegação lateral, para refletir o comportamento já existente no Tainacan, onde os itens do submenu ficam escondidos e só aparecem quando passa o mouse pelo item do menu Obatala.

(Sugestão dada por Matheus na última reunião)