### PR TITLE
Task-167: Criar endpoints na API para gerenciamento de setores

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-![Versão do Plugin](https://img.shields.io/badge/version-1.2.5-blue.svg)
+![Versão do Plugin](https://img.shields.io/badge/version-1.2.6-blue.svg)
 ![Compatibilidade com WordPress](https://img.shields.io/badge/WordPress-v5.7%2B-blue.svg)
 ![Licença](https://img.shields.io/badge/license-GPLv2-blue.svg)
 ![Tainacan](https://img.shields.io/badge/Tainacan-Addon-blue.svg)

--- a/obatala.php
+++ b/obatala.php
@@ -7,7 +7,7 @@ require_once __DIR__ . '/vendor/autoload.php';
 /*
 	Plugin Name: Obatala - Plugin de Gestão de Processos Curatoriais para WordPress
 	Description: Adiciona funcionalidades de gestão de processos curatoriais para o plugin Tainacan
-	Version: 1.2.5
+	Version: 1.2.6
 	Author: Douglas de Araújo
 	Author URI: github.com/everbero
 	License: GPLv2 or later

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "nocs-obatala",
-    "version": "1.2.5",
+    "version": "1.2.6",
     "private": true,
     "description": "Curatorial process manager for Tainacan",
     "author": "Nocs Lab",


### PR DESCRIPTION
Devido à recente decisão de transformar a gestão de setores de um Tipo de Post Personalizado (CPT) para um campo armazenado em WP_OPTIONS, realizamos uma revisão na lógica do sistema. Essa mudança visa simplificar a estrutura de dados e melhorar a eficiência do gerenciamento dos setores.

Com essa nova abordagem, os setores serão armazenados em um formato JSON na tabela de opções do WordPress, o que facilitará o acesso e a manipulação dos dados. Além disso, essa alteração permitirá uma melhor integração com outras funcionalidades do WordPress e facilitará futuras expansões do sistema.

Linck: https://tree.taiga.io/project/daltonmartins-gestao-digital-de-processos-curatoriais-para-acervos-de-museus/task/167
Linck Task-179: https://tree.taiga.io/project/daltonmartins-gestao-digital-de-processos-curatoriais-para-acervos-de-museus/task/179