### PR TITLE
Task-136: Implementar a funcionalidade para associar setores a etapas de processos

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-![Versão do Plugin](https://img.shields.io/badge/version-1.2.12-blue.svg)
+![Versão do Plugin](https://img.shields.io/badge/version-1.2.13-blue.svg)
 ![Compatibilidade com WordPress](https://img.shields.io/badge/WordPress-v5.7%2B-blue.svg)
 ![Licença](https://img.shields.io/badge/license-GPLv2-blue.svg)
 ![Tainacan](https://img.shields.io/badge/Tainacan-Addon-blue.svg)

--- a/classes/Api/ProcessApi.php
+++ b/classes/Api/ProcessApi.php
@@ -84,8 +84,30 @@ class ProcessApi extends ObatalaAPI {
                 ]
             ]
         ]);
-    }
 
+        // Funçao para associar e gerensiar historico de setores das etapas
+        $this->add_route('process_obatala/(?P<id>\d+)/assosiate_sector', [
+            'methods' => 'POST',
+            'callback' => [$this, 'assosiate_sector'],
+            'permission_callback' => '__return_true',
+            'args' => [
+                'sector_id' => [
+                    'required' => true,
+                    'validate_callback' => function($param) {
+                        return is_string($param);
+                    }
+                ],
+                'node_id' => [
+                    'required' => true,
+                    'validate_callback' => function($param) {
+                        return !empty($param) && is_string($param);
+                    }
+                ]
+            ]
+        ]);
+
+    }
+    
     public function get_current_stage($request) {
         $post_id = (int) $request['id'];
         return get_post_meta($post_id, 'current_stage', true);
@@ -160,4 +182,53 @@ class ProcessApi extends ObatalaAPI {
             return new WP_REST_Response('Error adding comment', 500);
         }
     }
+
+    public function assosiate_sector($request) {
+        // Obter os parâmetros do request
+        $process_id = (int) $request['id'];
+        $sector_id = sanitize_text_field($request['sector_id']);
+        $node_id = sanitize_text_field($request['node_id']);
+        
+        // Verificar se o processo existe
+        $process = get_post($process_id);
+        if (!$process || $process->post_type !== 'process_type') {
+            return new WP_REST_Response('Processo não encontrado ou tipo de processo inválido', 404);
+        }
+    
+        // Obter os dados do flowData do processo
+        $flow_data = get_post_meta($process_id, 'flowData', true);
+    
+        // Verificar se o flowData está configurado corretamente
+        if (!isset($flow_data['nodes']) || !is_array($flow_data['nodes'])) {
+            return new WP_REST_Response('Os dados do fluxo não estão configurados corretamente', 400);
+        }
+    
+        // Procurar o nó correspondente ao node_id fornecido
+        $node_key = array_search($node_id, array_column($flow_data['nodes'], 'id'));
+        if ($node_key === false) {
+            return new WP_REST_Response('Nó não encontrado nos dados do fluxo', 404);
+        }
+    
+        // Atualizar o current_sector
+        update_post_meta($process_id, 'current_sector', $sector_id);
+    
+        // Adicionar o setor ao histórico da etapa (node)
+        if (!isset($flow_data['nodes'][$node_key]['sector_history'])) {
+            $flow_data['nodes'][$node_key]['sector_history'] = [];
+        }
+    
+        // Adicionar o novo setor ao histórico
+        $flow_data['nodes'][$node_key]['sector_history'][] = $sector_id;
+    
+        // Atualizar o flowData com o novo histórico
+        $updated = update_post_meta($process_id, 'flowData', $flow_data);
+    
+        // Verificar se a atualização foi bem-sucedida
+        if ($updated) {
+            return new WP_REST_Response('Setor associado com sucesso', 200);
+        } else {
+            return new WP_REST_Response('Erro ao associar o setor', 500);
+        }
+    }
+
 }

--- a/classes/Entities/Process.php
+++ b/classes/Entities/Process.php
@@ -63,6 +63,13 @@ class Process {
             'show_in_rest' => true,
         ]);
 
+        register_meta('post', 'current_sector', [
+            'type' => 'integer',
+            'description' => 'Current Sector ID',
+            'single' => true,
+            'show_in_rest' => true,
+        ]);
+
         register_meta('comment', 'stage_id', [
             'type' => 'number',
             'description' => __('Estágio do Processo', 'obatala'),

--- a/classes/Entities/ProcessType.php
+++ b/classes/Entities/ProcessType.php
@@ -137,6 +137,12 @@ class ProcessType {
                                         'type' => 'string',
                                         'description' => 'Name of the stage (node)',
                                     ],
+                                    'sector_history' => [
+                                        'type' => 'array',
+                                        'sector_id' => [
+                                            'type' => 'string'
+                                        ]
+                                    ]
                                 ],
                             ],
                         ],

--- a/obatala.php
+++ b/obatala.php
@@ -7,7 +7,7 @@ require_once __DIR__ . '/vendor/autoload.php';
 /*
 	Plugin Name: Obatala - Plugin de Gestão de Processos Curatoriais para WordPress
 	Description: Adiciona funcionalidades de gestão de processos curatoriais para o plugin Tainacan
-	Version: 1.2.12
+	Version: 1.2.13
 	Author: Douglas de Araújo
 	Author URI: github.com/everbero
 	License: GPLv2 or later

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "nocs-obatala",
-    "version": "1.2.12",
+    "version": "1.2.13",
     "private": true,
     "description": "Curatorial process manager for Tainacan",
     "author": "Nocs Lab",


### PR DESCRIPTION
Foi adicionado um campo de meta dado ao processo para indicar o setor atual e implementado ao meta dado flow data um campo para identificar o histórico de setores (por onde aquela etapa passou).
Assim sempre que atualizar o setor atual ele atualiza o histórico das etapas.

[task-136]( https://tree.taiga.io/project/daltonmartins-gestao-digital-de-processos-curatoriais-para-acervos-de-museus/task/136)