### PR TITLE
Task-136: Implementar a funcionalidade para associar setores a etapas de processos

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-![Versão do Plugin](https://img.shields.io/badge/version-1.2.14-blue.svg)
+![Versão do Plugin](https://img.shields.io/badge/version-1.2.15-blue.svg)
 ![Compatibilidade com WordPress](https://img.shields.io/badge/WordPress-v5.7%2B-blue.svg)
 ![Licença](https://img.shields.io/badge/license-GPLv2-blue.svg)
 ![Tainacan](https://img.shields.io/badge/Tainacan-Addon-blue.svg)

--- a/classes/Entities/Process.php
+++ b/classes/Entities/Process.php
@@ -63,6 +63,13 @@ class Process {
             'show_in_rest' => true,
         ]);
 
+        register_meta('post', 'current_sector', [
+            'type' => 'integer',
+            'description' => 'Current Sector ID',
+            'single' => true,
+            'show_in_rest' => true,
+        ]);
+
         register_meta('comment', 'stage_id', [
             'type' => 'number',
             'description' => __('Estágio do Processo', 'obatala'),

--- a/classes/Entities/ProcessType.php
+++ b/classes/Entities/ProcessType.php
@@ -137,6 +137,12 @@ class ProcessType {
                                         'type' => 'string',
                                         'description' => 'Name of the stage (node)',
                                     ],
+                                    'sector_history' => [
+                                        'type' => 'array',
+                                        'sector_id' => [
+                                            'type' => 'string'
+                                        ]
+                                    ]
                                 ],
                             ],
                         ],

--- a/obatala.php
+++ b/obatala.php
@@ -7,7 +7,7 @@ require_once __DIR__ . '/vendor/autoload.php';
 /*
 	Plugin Name: Obatala - Plugin de Gestão de Processos Curatoriais para WordPress
 	Description: Adiciona funcionalidades de gestão de processos curatoriais para o plugin Tainacan
-	Version: 1.2.14
+	Version: 1.2.15
 	Author: Douglas de Araújo
 	Author URI: github.com/everbero
 	License: GPLv2 or later

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "nocs-obatala",
-    "version": "1.2.14",
+    "version": "1.2.15",
     "private": true,
     "description": "Curatorial process manager for Tainacan",
     "author": "Nocs Lab",


### PR DESCRIPTION
Foi adicionado um campo de meta dado ao processo para indicar o setor atual e implementado ao meta dado flow data um campo para identificar o histórico de setores (por onde aquela etapa passou).
Assim sempre que atualizar o setor atual ele atualiza o histórico das etapas.

[task-136]( https://tree.taiga.io/project/daltonmartins-gestao-digital-de-processos-curatoriais-para-acervos-de-museus/task/136)