### PR TITLE
Remove dependência de CPT sector_obatala ausente no método register_post_type_routes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-![Versão do Plugin](https://img.shields.io/badge/version-1.2.18-blue.svg)
+![Versão do Plugin](https://img.shields.io/badge/version-1.2.19-blue.svg)
 ![Compatibilidade com WordPress](https://img.shields.io/badge/WordPress-v5.7%2B-blue.svg)
 ![Licença](https://img.shields.io/badge/license-GPLv2-blue.svg)
 ![Tainacan](https://img.shields.io/badge/Tainacan-Addon-blue.svg)

--- a/classes/Api/CustomPostTypeApi.php
+++ b/classes/Api/CustomPostTypeApi.php
@@ -19,8 +19,6 @@ class CustomPostTypeApi extends ObatalaAPI {
         // Register routes for 'process_type' post type
         $this->register_post_type_routes('process_type');
 
-        // Register routes for 'sector_obatala' post type 
-        $this->register_post_type_routes('sector_obatala');
     }
 
     /**

--- a/obatala.php
+++ b/obatala.php
@@ -7,7 +7,7 @@ require_once __DIR__ . '/vendor/autoload.php';
 /*
 	Plugin Name: Obatala - Plugin de Gestão de Processos Curatoriais para WordPress
 	Description: Adiciona funcionalidades de gestão de processos curatoriais para o plugin Tainacan
-	Version: 1.2.18
+	Version: 1.2.19
 	Author: Douglas de Araújo
 	Author URI: github.com/everbero
 	License: GPLv2 or later

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "nocs-obatala",
-    "version": "1.2.18",
+    "version": "1.2.19",
     "private": true,
     "description": "Curatorial process manager for Tainacan",
     "author": "Nocs Lab",


### PR DESCRIPTION
Corrigindo erro ao chamar o método register_post_type_routes com um Custom Post Type inexistente, sector_obatala. Este erro foi causado pela exclusão do CPT anteriormente. A alteração remove o chamado para este CPT ausente e ajusta as dependências associadas.