### PR TITLE
[Task 231]: Criação de Endpoint para adicionar funcionalidade de upload de arquivos

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-![Versão do Plugin](https://img.shields.io/badge/version-1.2.27-blue.svg)
+![Versão do Plugin](https://img.shields.io/badge/version-1.2.28-blue.svg)
 ![Compatibilidade com WordPress](https://img.shields.io/badge/WordPress-v5.7%2B-blue.svg)
 ![Licença](https://img.shields.io/badge/license-GPLv2-blue.svg)
 ![Tainacan](https://img.shields.io/badge/Tainacan-Addon-blue.svg)

--- a/classes/Api/ProcessTypeApi.php
+++ b/classes/Api/ProcessTypeApi.php
@@ -367,8 +367,8 @@ class ProcessTypeApi extends ObatalaAPI {
     }
 
     public function download($request) {
-        $process_id = $request['id'];
-        $user_id = $request->get_param('user');
+        $process_id = intval($request['id']);
+        $user_id = intval($request->get_param('user'));
         $file_name = sanitize_file_name($request->get_param('file'));
 
         // Verificar permissão

--- a/classes/Api/ProcessTypeApi.php
+++ b/classes/Api/ProcessTypeApi.php
@@ -51,6 +51,18 @@ class ProcessTypeApi extends ObatalaAPI {
             'callback' => [$this, 'get_node'],
             'permission_callback' => '__return_true', // Ajuste conforme necessário
         ]);
+
+        $this->add_route('process_type/upload', [
+            'methods' => 'POST',
+            'callback' => [$this, 'upload'],
+            'permission_callback' => '__return_true',
+        ]);
+
+        $this->add_route('process_type/download', [
+            'methods' => 'GET',
+            'callback' => [$this, 'download'],
+            'permission_callback' => '__return_true',
+        ]);
     }
 
     protected function get_meta_args() {
@@ -231,5 +243,168 @@ class ProcessTypeApi extends ObatalaAPI {
                 'data_sector' => $permission['data_sector']
             ], 200);
         }
+    }
+
+    public function upload($request) {
+        $process_id = $request['id'];
+        $node_id = sanitize_text_field($request['node_id']);
+        // Carregar a função wp_handle_upload, se necessário
+        if (!function_exists('wp_handle_upload')) {
+            require_once ABSPATH . 'wp-admin/includes/file.php';
+        }
+
+        // Verificar se o arquivo foi enviado
+        if (empty($_FILES['file'])) {
+            return new WP_REST_Response([
+                'error' => 'Nenhum arquivo enviado',
+            ], 400);
+        }
+
+        $file = $_FILES['file'];
+        $overrides = [
+            'test_form' => false,
+            'mimes' => [
+                'doc' => 'application/msword',
+                'docx' => 'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
+                'pdf' => 'application/pdf',
+                'jpg' => 'image/jpeg',
+                'jpeg' => 'image/jpeg',
+                'png' => 'image/png',
+            ],
+        ];
+
+        // Diretório de upload personalizado
+        $upload_dir = wp_upload_dir();
+        $custom_dir = trailingslashit($upload_dir['basedir']) . 'obatala';
+
+        // Criar o diretório, se necessário
+        if (!wp_mkdir_p($custom_dir)) {
+            return new WP_REST_Response([
+                'error' => 'Não foi possível criar o diretório de upload personalizado.',
+            ], 500);
+        }
+
+        // Configurar o arquivo .htaccess para proteção
+        $htaccess_path = $custom_dir . '/.htaccess';
+        if (!file_exists($htaccess_path)) {
+            $htaccess_content = <<<EOT
+                    <IfModule mod_rewrite.c>
+                        RewriteEngine On
+
+                        # Bloquear acesso direto ao diretório e redirecionar ao WordPress
+                        RewriteCond %{REQUEST_FILENAME} -f
+                        RewriteRule ^ - [F]
+                    </IfModule>
+                EOT;
+            if (file_put_contents($htaccess_path, $htaccess_content) === false) {
+                return new WP_REST_Response([
+                    'error' => 'Erro ao criar o arquivo .htaccess no diretório de upload.',
+                ], 500);
+            }
+        }
+
+        // Fazer upload do arquivo
+        $uploaded_file = wp_handle_upload($file, $overrides);
+
+        if (isset($uploaded_file['error'])) {
+            return new WP_REST_Response([
+                'error' => $uploaded_file['error'],
+            ], 500);
+        }
+
+
+        // Modificar o nome do arquivo
+        $process_name = get_the_title($process_id);
+        $filename = sanitize_file_name($file['name']);
+        $filename_parts = pathinfo($filename);
+        $new_filename = $process_name . '-' .
+            $node_id . '-' . $filename_parts['filename'] . '.' .
+            $filename_parts['extension'];
+
+        // Mover o arquivo para o diretório personalizado
+        $filename = sanitize_file_name($new_filename);
+        $new_file_path = trailingslashit($custom_dir) . $filename;
+
+        if (!rename($uploaded_file['file'], $new_file_path)) {
+            return new WP_REST_Response([
+                'error' => 'Erro ao salvar o arquivo no diretório personalizado.',
+            ], 500);
+        }
+
+        // Obter os dados do flowData do processo
+        $flow_data = get_post_meta($process_id, 'flowData', true);
+
+        // Verificar se o flowData está configurado corretamente
+        if (!isset($flow_data['nodes']) || !is_array($flow_data['nodes'])) {
+            return new WP_REST_Response('Os dados do fluxo não estão configurados corretamente', 400);
+        }
+
+        // Procurar o nó correspondente ao node_id fornecido
+        $node_key = array_search($node_id, array_column($flow_data['nodes'], 'id'));
+        if ($node_key === false) {
+            return new WP_REST_Response('Nó não encontrado nos dados do fluxo', 404);
+        }
+
+        // Adicionar o file
+        if (!isset($flow_data['nodes'][$node_key]['file'])) {
+            $flow_data['nodes'][$node_key]['file'] = [];
+        }
+
+        // Adicionar o novo setor ao histórico sem deixar duplicatas
+        if (!in_array(basename($new_file_path), $flow_data['nodes'][$node_key]['file'])) {
+            $flow_data['nodes'][$node_key]['file'][] = basename($new_file_path);
+        }
+
+        // Atualizar o flowData com o novo histórico
+        update_post_meta($process_id, 'flowData', $flow_data);
+
+        // Retornar sucesso com o caminho do arquivo
+        return new WP_REST_Response([
+            'success' => true,
+            'message' => 'Arquivo enviado com sucesso.',
+            'file_path' => $new_file_path,
+        ], 200);
+    }
+
+    public function download($request) {
+        $process_id = $request['id'];
+        $user_id = $request->get_param('user');
+        $file_name = sanitize_file_name($request->get_param('file'));
+
+        // Verificar permissão
+        $permission = Sector::check_permission($user_id, $process_id);
+
+        if (!$permission['status']) {
+            return new WP_REST_Response(
+                [
+                    'error' => 'Permissão negada',
+                    'status' => $permission['message']
+                ],
+                403
+            );
+        }
+
+        // Caminho do arquivo
+        $upload_dir = wp_upload_dir();
+        $custom_dir = trailingslashit($upload_dir['basedir']) . 'obatala';
+        $file_path = trailingslashit($custom_dir) . $file_name;
+
+        if (!file_exists($file_path)) {
+            return new WP_REST_Response(
+                ['error' => 'Arquivo não encontrado'],
+                404
+            );
+        }
+
+        // Gerar a URL para o arquivo e retornar para o cliente
+        $file_url = trailingslashit($upload_dir['baseurl']) . 'obatala/' . $file_name;
+
+        return new WP_REST_Response(
+            [
+                'success' => true,
+                'file_url' => $file_url,
+            ],
+            200
+        );
     }
 }

--- a/classes/Entities/ProcessType.php
+++ b/classes/Entities/ProcessType.php
@@ -148,6 +148,12 @@ class ProcessType {
                                         'sector_id' => [
                                             'type' => 'string'
                                         ]
+                                    ],
+                                    'file' =>[
+                                        'type' => 'array',
+                                        'name' => [
+                                            'type' => 'string'
+                                        ]
                                     ]
                                 ],
                             ],

--- a/obatala.php
+++ b/obatala.php
@@ -7,7 +7,7 @@ require_once __DIR__ . '/vendor/autoload.php';
 /*
 	Plugin Name: Obatala - Plugin de Gestão de Processos Curatoriais para WordPress
 	Description: Adiciona funcionalidades de gestão de processos curatoriais para o plugin Tainacan
-	Version: 1.2.27
+	Version: 1.2.28
 	Author: Douglas de Araújo
 	Author URI: github.com/everbero
 	License: GPLv2 or later

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "nocs-obatala",
-    "version": "1.2.27",
+    "version": "1.2.28",
     "private": true,
     "description": "Curatorial process manager for Tainacan",
     "author": "Nocs Lab",


### PR DESCRIPTION
**Foram implementadas duas novas rotas na API:**

**Rota de Upload:**

- Permite o envio de arquivos nos formatos: pdf, doc, docx, jpg, jpeg e png.
- Os arquivos são armazenados em um diretório personalizado chamado obatala, dentro da pasta de uploads do WordPress.
- Foi adicionado um mecanismo para gerar nomes únicos para os arquivos enviados, com base no ID do processo e do nó.
- Implementação de um arquivo .htaccess no diretório de upload para reforçar a segurança, bloqueando o acesso direto aos arquivos.

**Rota de Download:**

- Permite que usuários autorizados baixem arquivos com base em suas permissões.
- Os arquivos são verificados quanto à existência antes de gerar a URL de download.

**Detalhes de Segurança:**

- O .htaccess foi configurado para evitar o acesso direto aos arquivos, utilizando as regras do mod_rewrite para proteger o diretório personalizado.
- A verificação de permissões foi incluída na rota de download, garantindo que apenas usuários autorizados possam acessar os arquivos.

**Motivação:**

- Essa funcionalidade facilita o gerenciamento de arquivos relacionados aos processos, garantindo maior segurança no armazenamento e controle de acesso.