### PR TITLE
fix: Validando existência de plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 
-![Versão do Plugin](https://img.shields.io/badge/version-1.4.14-blue.svg)
+![Versão do Plugin](https://img.shields.io/badge/version-1.4.15-blue.svg)
 ![Compatibilidade com WordPress](https://img.shields.io/badge/WordPress-v5.7%2B-blue.svg)
 ![Licença](https://img.shields.io/badge/license-GPLv2-blue.svg)
 ![Tainacan](https://img.shields.io/badge/Tainacan-Addon-blue.svg)

--- a/developer/updatePlugin.py
+++ b/developer/updatePlugin.py
@@ -23,21 +23,25 @@ def loginCuradoria(page):
         print(f"Erro ao realizar login: {e}")
         sys.exit(1) # Interrompe o script em caso de erro
 
+new_plugin_executado = False  # Váriável de controle
+
 def deactivePlugin(page):
+    global new_plugin_executado
     try:
         page.goto(page_plugin)
         page.click('[data-slug="obatala-plugin-de-gestao-de-processos-curatoriais-para-wordpress"] .row-actions.visible >> text=Deactivate')
         if page.wait_for_selector('text=Plugin deactivated.', timeout=5000):
             print("Desativação do plugin antigo: Sucesso")
     except Exception as e:
-        print(f"Erro ao desativar plugin: {e}")
-        sys.exit(1) 
+        print("Nenhum plugin ativo encontrado, adicionando nova versão...")
+        if not new_plugin_executado:
+            newPlugin(page)
+            new_plugin_executado = True  # Marca como executado
 
 def pathPlugin():
     plugin_path = "./developer/obatala.zip"
     if os.path.exists(plugin_path):
         print("Plugin encontrado.")
-        # Continue com o processamento do plugin
     else:
         print("Plugin não encontrado.")
         sys.exit(1) 
@@ -54,7 +58,7 @@ def newPlugin(page):
         page.click('xpath=/html/body/div[1]/div[2]/div[2]/div[1]/div[2]/p[4]/a[1]')
         page.wait_for_load_state("networkidle")
         if page.wait_for_selector('text=Plugin activated.', timeout=5000):
-            print("Ativação do novo plugin: Sucesso")
+            print("Adição do novo plugin: Sucesso")
     except Exception as e:
         print(f"Erro ao adicionar novo plugin: {e}")
         sys.exit(1) 
@@ -66,7 +70,9 @@ with sync_playwright() as p:
     pathPlugin()
     loginCuradoria(page)
     deactivePlugin(page)
-    newPlugin(page)
+    if not new_plugin_executado()
+        newPlugin(page)  # Só será chamado se não tiver sido executada.
+
     
 
 

--- a/obatala.php
+++ b/obatala.php
@@ -8,7 +8,7 @@ require_once __DIR__ . '/vendor/autoload.php';
 	Plugin Name: Obatala - Plugin de Gestão de Processos Curatoriais para WordPress
 	Description: Adiciona funcionalidades de gestão de processos curatoriais para o plugin Tainacan
 
-	Version: 1.4.14
+	Version: 1.4.15
 	Author: NOCs
 	License: GPLv2 or later
 	Text Domain: obatala

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "nocs-obatala",
-    "version": "1.4.14",
+    "version": "1.4.15",
     "private": true,
     "description": "Curatorial process manager for Tainacan",
     "author": "Nocs Lab",


### PR DESCRIPTION
Nessa adição de código foi criado uma lógica na qual vai verificar se existem plugins ativos ou desativados antes de fazer o upload de uma nova versão do obatalá.